### PR TITLE
add directory space use monitoring

### DIFF
--- a/bin/riemann-dir-space
+++ b/bin/riemann-dir-space
@@ -1,0 +1,55 @@
+#!/usr/bin/env ruby
+
+# Gathers the space used by a directory and submits it to riemann
+
+require File.expand_path('../../lib/riemann/tools', __FILE__)
+
+class Riemann::Tools::DirSpace
+  include Riemann::Tools
+
+  opt :directory, "", :default => '/var/log'
+  opt :service_prefix, "The first part of the service name, before the directory path", :default => "dir-space"
+  opt :warning, "Dir space warning threshold (in bytes)"
+  opt :critical, "Dir space critical threshold (in bytes)"
+  opt :alert_on_missing, "Send a critical metric if the directory is missing?", :default => true
+
+  def initialize
+    @dir = opts.fetch(:directory)
+    @service_prefix = opts.fetch(:service_prefix)
+    @warning = opts.fetch(:warning, nil)
+    @critical = opts.fetch(:critical, nil)
+    @alert_on_missing = opts.fetch(:alert_on_missing)
+  end
+
+  def tick
+    if Dir.exists?(@dir)
+      metric = `du '#{@dir}'`.lines.to_a.last.split("\t")[0].to_i
+      report(
+        :service => "#{@service_prefix} #{@dir}",
+        :metric => metric,
+        :state => state(metric),
+        :tags => ['dir_space']
+      )
+    elsif @alert_on_missing
+      report(
+        :service => "#{@service_prefix} #{@dir} missing",
+        :description => "#{@service_prefix} #{@dir} does not exist",
+        :metric => metric,
+        :state => 'critical',
+        :tags => ['dir_space']
+      )
+    end
+  end
+
+  def state(metric)
+    if @critical && metric > @critical
+      'critical'
+    elsif @warning && metric > @warning
+      'warning'
+    else
+      'ok'
+    end
+  end
+end
+
+Riemann::Tools::DirSpace.run


### PR DESCRIPTION
this can be useful if/when you want to ensure a specific directory
doesn't go over a certain size, or if you want to monitor a particular
directory's size.

I use it in production to monitor a few key directories, (with no
alerts), and when disk space is critical I use `coalesce` (with these
metrics and the riemann health disk space metric) to get an alert
description that includes the space use of said key directories (so I
can know it's e.g. graphite filling up, or /var/log filling up, or riak
filling up the disk