### PR TITLE
Added check and switch for Varnish 4

### DIFF
--- a/bin/riemann-varnish
+++ b/bin/riemann-varnish
@@ -2,6 +2,7 @@
 
 # Reports varnish stats to Riemann.
 
+require 'open3'
 require File.expand_path('../../lib/riemann/tools', __FILE__)
 
 class Riemann::Tools::Varnish
@@ -10,15 +11,32 @@ class Riemann::Tools::Varnish
   opt :varnish_host, "Varnish hostname", :default => `hostname`.chomp
 
   def initialize
-    @vstats = [ "client_conn", 
+    cmd = 'varnishstat -V'
+    Open3.popen3(cmd) do |stdin, stdout, stderr, wait_thr|
+      @ver = /varnishstat \(varnish-(\d+)/.match(stderr.read)[1].to_i
+    end
+
+    if @ver >= 4
+      @vstats = [ "MAIN.sess_conn",
+                "MAIN.sess_drop ",
+                "MAIN.client_req",
+                "MAIN.cache_hit",
+                "MAIN.cache_miss" ]
+    else
+      @vstats = [ "client_conn",
                 "client_drop",
                 "client_req",
                 "cache_hit",
                 "cache_miss" ]
+    end
   end
 
   def tick
-    stats = `varnishstat -1 -f #{@vstats.join(",")}`
+    if @ver >= 4
+      stats = `varnishstat -1 -f #{@vstats.join(" -f ")}`
+    else
+      stats = `varnishstat -1 -f #{@vstats.join(",")}`
+    end
     stats.each_line do |stat|
       m = stat.split()
       report(


### PR DESCRIPTION
Fixes #104.

Varnish 4+ changes the field names for Varnish statistics fields.

This change runs varnishstats -V (using popen3 because Varnish outputs
all version information to stderr and not stdout) and captures the
version via a regex.

A case statement switches on the version. A 4 or higher results in using
the new fields. Otherwise it defaults to the Varnish 3.x field names.

The command also had to change because the `-f` option no longer
supports a comma-separated list and now requires a glob or multiple
instantiations.