### PR TITLE
Fixed failed comparison of Fixnum with True

### DIFF
--- a/bin/riemann-dir-files-count
+++ b/bin/riemann-dir-files-count
@@ -9,8 +9,8 @@ class Riemann::Tools::DirFilesCount
 
   opt :directory, "", :default => '/var/log'
   opt :service_prefix, "The first part of the service name, before the directory path", :default => "dir-files-count"
-  opt :warning, "Dir files number warning threshold"
-  opt :critical, "Dir files number critical threshold"
+  opt :warning, "Dir files number warning threshold", :type => Integer
+  opt :critical, "Dir files number critical threshold", :type => Integer
   opt :alert_on_missing, "Send a critical metric if the directory is missing?", :default => true
 
   def initialize

--- a/bin/riemann-dir-space
+++ b/bin/riemann-dir-space
@@ -9,8 +9,8 @@ class Riemann::Tools::DirSpace
 
   opt :directory, "", :default => '/var/log'
   opt :service_prefix, "The first part of the service name, before the directory path", :default => "dir-space"
-  opt :warning, "Dir space warning threshold (in bytes)"
-  opt :critical, "Dir space critical threshold (in bytes)"
+  opt :warning, "Dir space warning threshold (in bytes)", :type => Integer
+  opt :critical, "Dir space critical threshold (in bytes)", :type => Integer
   opt :alert_on_missing, "Send a critical metric if the directory is missing?", :default => true
 
   def initialize


### PR DESCRIPTION
When setting :critical or :warning and using ruby 2.1, an "ArgumentError comparison of Fixnum with true failed" was obtained. These changes fix those errors.