### PR TITLE
Change the way `ioreqs` metric is handled

### DIFF
--- a/bin/riemann-diskstats
+++ b/bin/riemann-diskstats
@@ -63,13 +63,22 @@ class Riemann::Tools::Diskstats
 
     if @old_state
       state.each do |service, metric|
-        delta = metric - @old_state[service]
 
-        report(
-          :service => "diskstats " + service,
-          :metric => (delta.to_f / opts[:interval]),
-          :state => "ok"
-        )
+        if service =~ /io reqs$/
+          report(
+            :service => "diskstats " + service,
+            :metric => metric,
+            :state => "ok"
+          )
+        else
+          delta = metric - @old_state[service]
+
+          report(
+            :service => "diskstats " + service,
+            :metric => (delta.to_f / opts[:interval]),
+            :state => "ok"
+          )
+        end
 
         if service =~ /io time$/
           report(:service => "diskstats " + service.gsub(/time/, 'util'),


### PR DESCRIPTION
Indeed, it refers to the `in_flight` field in diskstat file and is the only field that should/might go to zero. I think it's better to report the metric as it, without modification.

It might also be worth to rename the metric name.

Source :

  - https://www.kernel.org/doc/Documentation/block/stat.txt
  - https://www.kernel.org/doc/Documentation/iostats.txt