### PR TITLE
Added docker-health tool

### DIFF
--- a/Rakefile.rb
+++ b/Rakefile.rb
@@ -28,6 +28,7 @@ gemspec = Gem::Specification.new do |s|
   s.add_dependency 'fog', '>= 1.4.0'
   s.add_dependency 'faraday', '>= 0.8.5'
   s.add_dependency 'nokogiri', '>= 1.5.6'
+  s.add_dependency 'docker-api', '=> 1.22.0'
 
   s.files = FileList['lib/**/*', 'bin/*', 'LICENSE', 'README.markdown'].to_a
   s.executables |= Dir.entries('bin/')

--- a/bin/riemann-docker-health
+++ b/bin/riemann-docker-health
@@ -1,0 +1,158 @@
+#!/usr/bin/env ruby
+
+# Reports current CPU, disk, load average, and memory use to riemann.
+
+require File.expand_path('../../lib/riemann/tools', __FILE__)
+require 'docker'
+require 'socket'
+
+class Riemann::Tools::DockerHealth
+  include Riemann::Tools
+  include Docker
+
+  opt :docker_host, "Docker Container Host (see https://github.com/swipely/docker-api#host)", :default => nil
+  opt :cpu_warning, "CPU warning threshold (fraction of total jiffies)", :default => 0.9
+  opt :cpu_critical, "CPU critical threshold (fraction of total jiffies)", :default => 0.95
+  opt :disk_warning, "Disk warning threshold (fraction of space used)", :default => 0.9
+  opt :disk_critical, "Disk critical threshold (fraction of space used)", :default => 0.95
+  opt :memory_warning, "Memory warning threshold (fraction of RAM)", :default => 0.85
+  opt :memory_critical, "Memory critical threshold (fraction of RAM)", :default => 0.95
+  opt :checks, "A list of checks to run.", :type => :strings, :default => ['cpu', 'memory', 'disk']
+
+  def get_containers
+    Docker::Container.all
+  end
+
+  def get_container_name(container)
+    container.json['Name'][1..-1]
+  end
+
+  def initialize
+
+    if (opts[:docker_host] != nil)
+      Docker.url = opts[:docker_host]
+    end
+
+    @hostname = Socket.gethostname
+    @cpu_coefficient = 1000 * 1000 * 1000
+
+    @limits = {
+      :cpu => {:critical => opts[:cpu_critical], :warning => opts[:cpu_warning]},
+      :disk => {:critical => opts[:disk_critical], :warning => opts[:disk_warning]},
+      :memory => {:critical => opts[:memory_critical], :warning => opts[:memory_warning]}
+    }
+
+    @last_cpu_reads = Hash.new
+
+    opts[:checks].each do |check|
+      case check
+      when 'disk'
+        @disk_enabled = true
+      when 'cpu'
+        @cpu_enabled = true
+      when 'memory'
+        @memory_enabled = true
+      end
+    end
+  end
+
+  def alert(container, service, state, metric, description)
+
+    opts = {  :service => service.to_s,
+              :state => state.to_s,
+              :metric => metric.to_f,
+              :description => description }
+
+    if (container != nil)
+      opts[:host] = "#{@hostname}-#{container}"
+    end
+
+    report(opts)
+  end
+
+  def report_pct(container, service, fraction, report = '', name = nil)
+    if fraction
+
+      if (name == nil)
+        name = service
+      end
+
+      if fraction > @limits[service][:critical]
+        alert container, name, :critical, fraction, "#{sprintf("%.2f", fraction * 100)}% #{report}"
+      elsif fraction > @limits[service][:warning]
+        alert container, name, :warning, fraction, "#{sprintf("%.2f", fraction * 100)}% #{report}"
+      else
+        alert container, name, :ok, fraction, "#{sprintf("%.2f", fraction * 100)}% #{report}"
+      end
+    end
+  end
+
+
+  def cpu(id, name, stats)
+
+    current = stats['precpu_stats']['cpu_usage']['total_usage']
+    unless current
+      alert name, :cpu, :unknown, nil, 'no total usage found in docker remote api stats'
+      return false
+    end
+
+    current_time = Time.parse(stats['read']);
+    if (@last_cpu_reads[id] != nil)
+      last = @last_cpu_reads[id]
+      used = (current - last[:v]) / (current_time - last[:t]) / @cpu_coefficient
+
+      report_pct name, :cpu, used
+    end
+
+    @last_cpu_reads[id] = { v: current, t: current_time }
+  end
+
+  def memory(id, name, stats)
+    memory_stats = stats['memory_stats']
+    usage = memory_stats['usage'].to_f
+    total = memory_stats['limit'].to_f
+    fraction = (usage / total)
+
+    report_pct name, :memory, fraction
+  end
+
+  def disk
+    `df -P`.split(/\n/).each do |r|
+      f = r.split(/\s+/)
+      next if f[0] == 'Filesystem'
+      next unless f[0] =~ /\// # Needs at least one slash in the mount path
+
+      # Calculate capacity
+      x = f[4].to_f/100
+      report_pct(nil, :disk, x, "#{f[3].to_i / 1024} mb left", "disk #{f[5]}")
+    end
+  end
+
+  def tick
+
+    # Disk is the same in every container
+    if @disk_enabled
+      disk()
+    end
+
+    # Get CPU, Memory and Load of each container
+    containers = get_containers()
+    containers.each do |container|
+
+      id = container.id
+      name = get_container_name(container)
+
+      stats = Docker::Util.parse_json(container.connection.get("/containers/#{id}/stats", {stream:false}))
+
+      if @cpu_enabled
+        cpu(id, name, stats)
+      end
+      if @memory_enabled
+        memory(id, name, stats)
+      end
+    end
+
+  end
+end
+
+Riemann::Tools::DockerHealth.run


### PR DESCRIPTION
Hi! 

I've created the docker-health tool that I was talking about in #119 

It works using the docker remote API and the `/container/_/stats` command (without stream).

Some open issues : 

* I could have made it _better_ using the "streaming" mode of the stats command, But this is out of my league in Ruby
* I could have made it run _faster_ using some parallel for-each instead of normal for-each
* The `host` that given for each container is determined by the host and container name (eg. `host-container`)
* No `load` option for this one, because the tick time is every 10 seconds, I think that it's alright, If people will want `load`, they can use riemann streams to mimic the behaviour
* The disk usage is still working using the code in `riemann-health` tool
* I've added dependency on `docker-api` gem

This is how it looks 

![screen shot 2015-07-18 at 7 10 43 pm](https://cloud.githubusercontent.com/assets/746471/8762429/29e28984-2d81-11e5-973c-20d2244b5d37.png)