### PR TITLE
Add support for monitoring the status of a Gitlab instance

### DIFF
--- a/bin/riemann-gitlab-status
+++ b/bin/riemann-gitlab-status
@@ -1,0 +1,58 @@
+#!/usr/bin/env ruby
+
+# Gathers Gitlab components' statuses and uptimes to submit them to Riemann.
+# See http://doc.gitlab.com/omnibus/maintenance/README.html
+
+require File.expand_path('../../lib/riemann/tools', __FILE__)
+
+class Riemann::Tools::GitLab
+  include Riemann::Tools
+
+  opt :command, "GitLab Status Command", :default => 'gitlab-ctl status'
+  opt :components, "Gitlab Components to monitor", :type => :strings, :multi => true, :default => ["nginx", "unicorn", "redis", "sidekiq"]
+
+  def initialize
+    @command = opts[:command]
+    @components = opts[:components].to_set
+    # sample output:
+    #
+    # run: logrotate: (pid 32713) 706s; run: log: (pid 5834) 53799s
+    # down: nginx: 3s, normally up; run: log: (pid 5725) 55653s
+    # run: redis: (pid 5564) 53824s; run: log: (pid 5563) 53824s
+    # run: sidekiq: (pid 5663) 53811s; run: log: (pid 5662) 53811s
+    # down: unicorn: 3s, normally up; run: log: (pid 5613) 55627s
+    @component_up_re = /^run: (\S+): \(pid \d+\) (\d+)s;/
+  end
+
+  def get_statuses
+    statuses = Hash.new
+    `#{@command}`.each_line { |line|
+      status = @component_up_re.match(line)
+      if !status.nil?
+        statuses[status[1]] = status[2].to_i
+      end
+    }
+    statuses
+  end
+
+  def report_uptime(component, value)
+    report({
+      :service     => "gitlab #{component}",
+      :state       => value > 0 ? 'ok' : 'critical',
+      :description => "Component #{component} was up for #{value} seconds",
+      :metric      => value,
+      :tags        => ['gitlab', "#{component}"]
+    })
+  end
+
+  def tick
+    statuses = get_statuses
+    @components.each { |component|
+      uptime = statuses[component]
+      report_uptime(component, uptime.nil? ? 0 : uptime)
+    }
+  end
+
+end
+
+Riemann::Tools::GitLab.run


### PR DESCRIPTION
This adds support for monitor the uptime of a Gitlab CE or EE instance through its `status` command:

```sh
$ gitlab-ctl status
run: logrotate: (pid 20055) 442s; run: log: (pid 5834) 76135s
run: nginx: (pid 20718) 374s; run: log: (pid 5725) 76141s
run: redis: (pid 20084) 441s; run: log: (pid 5563) 76160s
run: sidekiq: (pid 20102) 438s; run: log: (pid 5662) 76147s
run: unicorn: (pid 20122) 436s; run: log: (pid 5613) 76154s
```

The command returns the status and uptime for the [individual components](https://github.com/gitlabhq/gitlabhq/blob/v7.13.5/doc/development/architecture.md#components) composing each instance.

That command is used because Gitlab (as of 7.13.5) has no 'status' page in its [REST API](https://github.com/gitlabhq/gitlabhq/tree/v7.13.5/doc/api#resources) or UI that could be polled like [`riemann-apache-status`](https://github.com/aphyr/riemann-tools/blob/0.2.7/bin/riemann-apache-status#L3) and [`riemann-nginx-status`](https://github.com/aphyr/riemann-tools/blob/0.2.7/bin/riemann-nginx-status#L3) do.

This was tested on Centos 6 against both the [CE](https://packages.gitlab.com/gitlab/gitlab-ce) and [EE](https://packages.gitlab.com/gitlab/gitlab-ee) versions of Gitlab.

The limitation of the proposed approach is that support only the [Ommibus versions](https://github.com/gitlabhq/gitlabhq/blob/v7.13.5/doc/development/omnibus.md#what-you-should-know-about-omnibus-packages). Ommibus versions [bundle](https://github.com/chef/omnibus) Gitlab with its dependencies (Nginx, Unicorn, Redis and Postgres) and is the common way that people [install Gitlab](https://about.gitlab.com/installation/) unless you install it from source.