### PR TITLE
Add Marathon watcher

### DIFF
--- a/bin/riemann-marathon
+++ b/bin/riemann-marathon
@@ -1,0 +1,96 @@
+#!/usr/bin/env ruby
+
+require File.expand_path('../../lib/riemann/tools', __FILE__)
+
+class Riemann::Tools::Marathon
+  include Riemann::Tools
+
+  require 'faraday'
+  require 'json'
+  require 'uri'
+
+  opt :read_timeout, 'Faraday read timeout', type: :int, default: 2
+  opt :open_timeout, 'Faraday open timeout', type: :int, default: 1
+  opt :path_prefix, 'Marathon path prefix for proxied installations e.g. "marathon" for target http://localhost/marathon/metrics', default: "/"
+  opt :marathon_host, 'Marathon host', default: "localhost"
+  opt :marathon_port, 'Marathon port', type: :int, default: 8080
+
+  def initialize
+    options[:interval] = 60
+    options[:ttl] = 60
+  end
+
+  # Handles HTTP connections and GET requests safely
+  def safe_get(uri)
+      # Handle connection timeouts
+      response = nil
+      begin
+        connection = Faraday.new(uri)
+        response = connection.get do |req|
+          req.options[:timeout] = options[:read_timeout]
+          req.options[:open_timeout] = options[:open_timeout]
+        end
+      rescue => e
+        report(:host => uri.host,
+          :service => "marathon health",
+          :state => "critical",
+          :description => "HTTP connection error: #{e.class} - #{e.message}"
+        )
+      end
+      response
+  end
+
+  def health_url
+    path_prefix = options[:path_prefix]
+    path_prefix[0] = '' if path_prefix[0]=='/'
+    path_prefix[path_prefix.length-1] = '' if path_prefix[path_prefix.length-1]=='/'
+    "http://#{options[:marathon_host]}:#{options[:marathon_port]}#{path_prefix.length>0?'/':''}#{path_prefix}/metrics"
+  end
+
+  def tick
+    uri = URI(health_url)
+    response = safe_get(uri)
+
+    return if response.nil?
+
+    if response.status != 200
+        report(:host => uri.host,
+          :service => "marathon health",
+          :state => "critical",
+          :description => "HTTP connection error: #{response.status} - #{response.body}"
+        )
+    else
+      # Assuming that a 200 will give json
+      json = JSON.parse(response.body)
+      state = "green"
+
+      report(:host => uri.host,
+             :service => "marathon health",
+             :state => state)
+
+      json.each_pair do |t, d|
+        if d.respond_to? :each_pair
+          d.each_pair do |service, counters|
+            report(:host => uri.host,
+                   :service => "marathon_metric #{t} #{service}",
+                   :metric => 1,
+                   :tags => ["metric_name"]
+            )
+            if counters.respond_to? :each_pair
+              counters.each_pair do |k, v|
+                if v.is_a? Numeric
+                  report(:host => uri.host,
+                         :service => "marathon #{service} #{k}",
+                         :metric => v,
+                         :tags => ["metric", "#{t}"]
+                  )
+                end
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end
+Riemann::Tools::Marathon.run


### PR DESCRIPTION
Fetches metrics from /metrics endpoint in
[Marathon](https://mesosphere.github.io/marathon/) and pushes them to
riemann. This is derived from the elasticsearch watcher.