### PR TITLE
Corrects a typo when specifying dependencies.

### DIFF
--- a/Rakefile.rb
+++ b/Rakefile.rb
@@ -28,7 +28,7 @@ gemspec = Gem::Specification.new do |s|
   s.add_dependency 'fog', '>= 1.4.0'
   s.add_dependency 'faraday', '>= 0.8.5'
   s.add_dependency 'nokogiri', '>= 1.5.6'
-  s.add_dependency 'docker-api', '=> 1.22.0'
+  s.add_dependency 'docker-api', '>= 1.22.0'
 
   s.files = FileList['lib/**/*', 'bin/*', 'LICENSE', 'README.markdown'].to_a
   s.executables |= Dir.entries('bin/')


### PR DESCRIPTION
I believe there's a typo in the dependency specification:
```
mareknowak@Mareks-MacBook-Pro: ~/stuff/riemann-tools master
$ rake gem                                                                   [12:44:39]
rake aborted!
Gem::Requirement::BadRequirementError: Illformed requirement ["=> 1.22.0"]
/Users/mareknowak/stuff/riemann-tools/Rakefile.rb:31:in `block in <top (required)>'
/Users/mareknowak/stuff/riemann-tools/Rakefile.rb:11:in `new'
/Users/mareknowak/stuff/riemann-tools/Rakefile.rb:11:in `<top (required)>'
(See full trace by running task with --trace)
FAIL: 1

mareknowak@Mareks-MacBook-Pro: ~/stuff/riemann-tools master
$ sed -i "" "s/=>/>=/g" Rakefile.rb                                          [12:44:49]

mareknowak@Mareks-MacBook-Pro: ~/stuff/riemann-tools master ⚡
$ rake gem                                                                   [12:44:55]
# irrelevant output truncated
  Successfully built RubyGem
  Name: riemann-tools
  Version: 0.2.6
  File: riemann-tools-0.2.6.gem
# irrelevant output truncated
```
I have looked for mentions of the `=>` operator, but couldn't find anything.